### PR TITLE
Fix warning

### DIFF
--- a/lib/ruboty/zoi.rb
+++ b/lib/ruboty/zoi.rb
@@ -35,7 +35,7 @@ module Ruboty
 
       def fetch_data
         return @fetched_data if @fetched_data
-        zoi_data = open(ZOI_DATA_URI).read
+        zoi_data = URI(ZOI_DATA_URI).read
         zoi_data = zoi_data.
           match(/this.items = (.+?);/m)[1].
           gsub(/(word|image|src):/, "'\\1':").


### PR DESCRIPTION
```
warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```

And this may fix opened IO leak.